### PR TITLE
Reduce the amount of languages offered for selection

### DIFF
--- a/basxconnect/core/models/persons.py
+++ b/basxconnect/core/models/persons.py
@@ -1,9 +1,11 @@
 from bread.utils import get_concrete_instance, pretty_modelname
+from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from languages.fields import LanguageField
 
+from .. import settings
 from .utils import Note, Term
 
 
@@ -22,7 +24,9 @@ class Person(models.Model):
     preferred_language = LanguageField(
         _("Prefered Language"), blank=True, max_length=8
     )  # mitigate up-stream bug
-    # TODO: should we use our Term model to save languages?
+    preferred_language.lazy_choices = (
+        lambda field, request, instance: settings.PREFERRED_LANGUAGES
+    )
 
     notes = GenericRelation(Note)
 

--- a/basxconnect/core/settings.py
+++ b/basxconnect/core/settings.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+DEFAULTS = {"PREFERRED_LANGUAGES": (("en", "English"),)}
+
+PREFERRED_LANGUAGES = getattr(settings, "BASXCONNECT", DEFAULTS)["PREFERRED_LANGUAGES"]


### PR DESCRIPTION
There are over 8000 languages available in the django language field. This is a performance problem because they put unnecessary load on the server and the client (this is visible/detectable by eye and I did a little profiling).
A solution proposed in this PR is to use the "lazy_choices". Simply using "choices" on the model field would be problematic because every instance of basxconnect would generate a new migration for their specific choices which is very problematic for updates. But we have the lazy_choices feature in bread which does the same thing as choices but on the form field. I had to fix this because it was still relying on the older materialize-based implementation. So bread needs to be updated as well in order to use this.
Another solution would be to have the languages in a separate table filled either by us, the user or through an existing package. However, I think the approach in the PR is sufficient flexible and also somewhat lightweight.