### PR TITLE
use word "mailchimp" instead of "external mailer"

### DIFF
--- a/basxconnect/mailer_integration/abstract/mailer.py
+++ b/basxconnect/mailer_integration/abstract/mailer.py
@@ -46,7 +46,7 @@ class MailingInterest(NamedTuple):
     name: str
 
 
-class Datasource(metaclass=abc.ABCMeta):
+class AbstractMailer(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def get_persons(self) -> List[MailerPerson]:
         pass

--- a/basxconnect/mailer_integration/abstract/mailer.py
+++ b/basxconnect/mailer_integration/abstract/mailer.py
@@ -48,6 +48,10 @@ class MailingInterest(NamedTuple):
 
 class AbstractMailer(metaclass=abc.ABCMeta):
     @abc.abstractmethod
+    def name(self) -> str:
+        pass
+
+    @abc.abstractmethod
     def get_persons(self) -> List[MailerPerson]:
         pass
 

--- a/basxconnect/mailer_integration/mailchimp/mailer.py
+++ b/basxconnect/mailer_integration/mailchimp/mailer.py
@@ -19,6 +19,9 @@ class Mailchimp(mailer.AbstractMailer):
             {"api_key": settings.MAILCHIMP_API_KEY, "server": settings.MAILCHIMP_SERVER}
         )
 
+    def name(self) -> str:
+        return "Mailchimp"
+
     def get_persons(self) -> List[MailerPerson]:
         segment = self.client.lists.get_segment_members_list(
             list_id=settings.MAILCHIMP_LIST_ID,

--- a/basxconnect/mailer_integration/mailchimp/mailer.py
+++ b/basxconnect/mailer_integration/mailchimp/mailer.py
@@ -4,18 +4,15 @@ from typing import List
 import mailchimp_marketing
 from django.conf import settings
 
-from basxconnect.mailer_integration.abstract import abstract_datasource
-from basxconnect.mailer_integration.abstract.abstract_datasource import (
-    MailerPerson,
-    MailingInterest,
-)
+from basxconnect.mailer_integration.abstract import mailer
+from basxconnect.mailer_integration.abstract.mailer import MailerPerson, MailingInterest
 from basxconnect.mailer_integration.mailchimp.parsing import (
     create_mailer_person_from_raw,
 )
 from basxconnect.mailer_integration.models import Interest
 
 
-class MailchimpDatasource(abstract_datasource.Datasource):
+class Mailchimp(mailer.AbstractMailer):
     def __init__(self) -> None:
         self.client = mailchimp_marketing.Client()
         self.client.set_config(

--- a/basxconnect/mailer_integration/mailchimp/parsing.py
+++ b/basxconnect/mailer_integration/mailchimp/parsing.py
@@ -3,7 +3,7 @@ from typing import List
 
 from django.conf import settings
 
-from basxconnect.mailer_integration.abstract.abstract_datasource import MailerPerson
+from basxconnect.mailer_integration.abstract.mailer import MailerPerson
 
 logger = logging.getLogger(__name__)
 

--- a/basxconnect/mailer_integration/settings.py
+++ b/basxconnect/mailer_integration/settings.py
@@ -1,3 +1,3 @@
-from basxconnect.mailer_integration.mailchimp.datasource import MailchimpDatasource
+from basxconnect.mailer_integration.mailchimp.mailer import Mailchimp
 
-MAILER = MailchimpDatasource()
+MAILER = Mailchimp()

--- a/basxconnect/mailer_integration/synchronize.py
+++ b/basxconnect/mailer_integration/synchronize.py
@@ -2,10 +2,7 @@ import django_countries
 from django.utils import timezone
 
 from basxconnect.core import models
-from basxconnect.mailer_integration.abstract.abstract_datasource import (
-    Datasource,
-    MailerPerson,
-)
+from basxconnect.mailer_integration.abstract.mailer import AbstractMailer, MailerPerson
 from basxconnect.mailer_integration.models import (
     Interest,
     Subscription,
@@ -14,11 +11,11 @@ from basxconnect.mailer_integration.models import (
 )
 
 
-def synchronize(datasource: Datasource) -> SynchronizationResult:
-    synchronize_interests(datasource)
+def synchronize(mailer: AbstractMailer) -> SynchronizationResult:
+    synchronize_interests(mailer)
 
-    mailer_persons = datasource.get_persons()
-    datasource_tag = _get_or_create_tag(datasource.tag())
+    mailer_persons = mailer.get_persons()
+    datasource_tag = _get_or_create_tag(mailer.tag())
     sync_result = SynchronizationResult.objects.create()
     for mailer_person in mailer_persons:
         matching_email_addresses = list(

--- a/basxconnect/mailer_integration/views.py
+++ b/basxconnect/mailer_integration/views.py
@@ -13,8 +13,8 @@ from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 
 from basxconnect.mailer_integration import settings
-from basxconnect.mailer_integration.abstract.abstract_datasource import MailerPerson
-from basxconnect.mailer_integration.mailchimp import datasource
+from basxconnect.mailer_integration.abstract.mailer import MailerPerson
+from basxconnect.mailer_integration.mailchimp import mailer
 from basxconnect.mailer_integration.models import (
     SynchronizationPerson,
     SynchronizationResult,
@@ -192,7 +192,7 @@ class EditSubscriptionView(EditView):
     def post(self, request, *args, **kwargs):
         result = super().post(request, *args, **kwargs)
         # TODO: https://github.com/basxsoftwareassociation/basxconnect/issues/140
-        datasource.MailchimpDatasource().put_person(
+        mailer.Mailchimp().put_person(
             MailerPerson.from_mailing_preferences(self.object)
         )
         return result

--- a/basxconnect/mailer_integration/views.py
+++ b/basxconnect/mailer_integration/views.py
@@ -111,10 +111,6 @@ def display_previous_execution(request):
                         _("Newly added to BasxConnect"),
                         display_sync_persons(SynchronizationPerson.NEW),
                     ),
-                    DataTableColumn(
-                        _("Synchronized previously but not this time"),
-                        display_sync_persons(SynchronizationPerson.PREVIOUSLY_SYNCED),
-                    ),
                 ],
                 title=_("Previous Executions"),
                 primary_button="",

--- a/basxconnect/mailer_integration/views.py
+++ b/basxconnect/mailer_integration/views.py
@@ -159,7 +159,7 @@ menu.registeritem(
             reverse_lazy(
                 "basxconnect.mailer_integration.views.mailer_synchronization_view"
             ),
-            _("External mailer"),
+            settings.MAILER.name(),
             iconname="email",
         ),
         tools_group,

--- a/basxconnect/mailer_integration/views.py
+++ b/basxconnect/mailer_integration/views.py
@@ -127,7 +127,7 @@ def display_previous_execution(request):
                     )
                 ],
             ),
-            width=12,
+            width=16,
         )
     )
 


### PR DESCRIPTION
On a technical level it makes sense to separate the concepts of an arbitrary external mailer and a specific one (mailchimp), but for the user this is not really interesting.

Also, I can't stop renaming these modules as I am not 100% happy yet 😄 