### PR TITLE
add: edit-button for meta-data

### DIFF
--- a/basxconnect/core/layouts/editperson/common/utils.py
+++ b/basxconnect/core/layouts/editperson/common/utils.py
@@ -41,7 +41,7 @@ def person_metadata(model):
             ),
         ),
         open_modal_popup_button(
-            "", model, f"{model._meta.model_name}_ajax_edit_metadata"
+            _("Meta data"), model, f"{model._meta.model_name}_ajax_edit_metadata"
         ),
         style="border-left: none;",
     )

--- a/basxconnect/core/layouts/editperson/common/utils.py
+++ b/basxconnect/core/layouts/editperson/common/utils.py
@@ -16,12 +16,13 @@ C = layout.grid.Col
 F = layout.forms.FormField
 
 
-def person_metadata():
+def person_metadata(model):
     return tiling_col(
         # we need this to take exactly as much space as a real header
         hg.DIV("", style="margin-bottom:3.25rem;"),
         display_field_label_and_value("personnumber"),
         display_field_label_and_value("maintype"),
+        display_field_label_and_value("type"),
         display_label_and_value(_("Status"), active_toggle()),
         display_label_and_value(
             _("Changed"),
@@ -38,6 +39,9 @@ def person_metadata():
                 " / ",
                 hg.C("object.history.last.history_user"),
             ),
+        ),
+        open_modal_popup_button(
+            "", model, f"{model._meta.model_name}_ajax_edit_metadata"
         ),
         style="border-left: none;",
     )

--- a/basxconnect/core/layouts/editperson/legalperson/base_data_tab.py
+++ b/basxconnect/core/layouts/editperson/legalperson/base_data_tab.py
@@ -31,7 +31,7 @@ def base_data_tab(request):
                             "name_addition",
                         ],
                     ),
-                    person_metadata(),
+                    person_metadata(models.LegalPerson),
                 ),
                 common_tiles(request),
             ),

--- a/basxconnect/core/layouts/editperson/naturalperson/base_data_tab.py
+++ b/basxconnect/core/layouts/editperson/naturalperson/base_data_tab.py
@@ -22,7 +22,7 @@ def base_data_tab(request):
         utils.grid_inside_tab(
             R(
                 personal_data(),
-                person_metadata(),
+                person_metadata(models.NaturalPerson),
             ),
             base_data.common_tiles(request),
         ),

--- a/basxconnect/core/layouts/editperson/personassociation/base_data_tab.py
+++ b/basxconnect/core/layouts/editperson/personassociation/base_data_tab.py
@@ -29,7 +29,7 @@ def base_data_tab(request):
                         "salutation_letter",
                     ],
                 ),
-                person_metadata(),
+                person_metadata(models.PersonAssociation),
             ),
             base_data.common_tiles(request),
         ),

--- a/basxconnect/core/urls.py
+++ b/basxconnect/core/urls.py
@@ -1,6 +1,6 @@
 from bread import views as breadviews
 from bread.utils.urls import autopath, default_model_paths, model_urlname, reverse_model
-from bread.views import AddView
+from bread.views import AddView, EditView
 from django.views.generic import RedirectView
 
 import basxconnect.core.views.tag_views
@@ -183,6 +183,13 @@ urlpatterns = [
         person_modals_views.PersonAssociationEditTagsView.as_view(),
         urlname=model_urlname(models.PersonAssociation, "ajax_edit_tags"),
     ),
+    *[
+        autopath(
+            EditView._with(model=m, fields=["personnumber", "type"]).as_view(),
+            urlname=model_urlname(m, f"{m._meta.model_name}_ajax_edit_metadata"),
+        )
+        for m in [models.NaturalPerson, models.LegalPerson, models.PersonAssociation]
+    ],
     autopath(
         person_details_views.confirm_delete_email,
         urlname=model_urlname(models.Email, "delete"),


### PR DESCRIPTION
We should have a way to modify the person type and the person number where we display the meta data. If it is not a good fit for some project I suggest we just remove the "edit" button per project. But I think py default this should be easy accessible for editing.